### PR TITLE
Feature/csardi sync appdirs

### DIFF
--- a/R/cache.r
+++ b/R/cache.r
@@ -42,6 +42,7 @@
 user_cache_dir <- function(appname = NULL, appauthor = appname, version = NULL,
                            opinion = TRUE, expand = TRUE, os = get_os()) {
   if (expand) version <- expand_r_libs_specifiers(version)
+  if (is.null(appname)) { version <- NULL }
   switch(os, 
     win = file_path(win_path("local"), appauthor, appname, version, 
       if (opinion) "Cache"),

--- a/R/cache.r
+++ b/R/cache.r
@@ -4,7 +4,7 @@
 #'
 #' \itemize{
 #'  \item Mac OS X: \file{~/Library/Caches/<AppName>}
-#'  \item Unix: \file{~/.cache/<appname>}, \env{$XDG_CACHE_HOME} if defined
+#'  \item Unix: \file{~/.cache/<AppName>}, \env{$XDG_CACHE_HOME} if defined
 #'  \item Win XP: \file{C:\\Documents and Settings\\<username>\\Local Settings\\Application Data\\<AppAuthor>\\<AppName>\\Cache}
 #'  \item Vista:      \file{C:\\Users\\<username>\\AppData\\Local\\<AppAuthor>\\<AppName>\\Cache}
 #' }

--- a/R/data.r
+++ b/R/data.r
@@ -8,7 +8,7 @@
 #'
 #' \itemize{
 #'   \item Mac OS X:  \file{~/Library/Application Support/<AppName>}
-#'   \item Unix: \file{~/.local/share/<appname>}, in \env{$XDG_DATA_HOME} if defined
+#'   \item Unix: \file{~/.local/share/<AppName>}, in \env{$XDG_DATA_HOME} if defined
 #'   \item Win XP (not roaming):  \file{C:\\Documents and Settings\\<username>\\Data\\<AppAuthor>\\<AppName>}
 #'   \item Win XP (roaming): \file{C:\\Documents and Settings\\<username>\\Local Settings\\Data\\<AppAuthor>\\<AppName>}
 #'   \item Win 7  (not roaming): 
@@ -18,7 +18,7 @@
 #' }
 #' Unix also specifies a separate location for user configuration data in
 #' \itemize{ 
-#'   \item Unix: \file{~/.config/<appname>}, in \env{$XDG_CONFIG_HOME} if defined
+#'   \item Unix: \file{~/.config/<AppName>}, in \env{$XDG_CONFIG_HOME} if defined
 #'  }
 #' See for example \url{http://ploum.net/184-cleaning-user-preferences-keeping-user-data/} 
 #' or \url{http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html} for more information.
@@ -105,7 +105,7 @@ user_config_dir <- function(appname = NULL, appauthor = appname, version = NULL,
 #' }
 #' Unix also specifies a separate location for user-shared configuration data in \env{$XDG_CONFIG_DIRS}.
 #' \itemize{ 
-#'   \item Unix: \file{/etc/xdg/<appname>}, in \env{$XDG_CONFIG_HOME} if defined
+#'   \item Unix: \file{/etc/xdg/<AppName>}, in \env{$XDG_CONFIG_HOME} if defined
 #'  }
 #' 
 #' For Unix, this returns the first default.  Set the \code{multipath=TRUE} to guarantee returning all directories.

--- a/R/data.r
+++ b/R/data.r
@@ -25,14 +25,16 @@
 #' Arguably plugins such as R packages should go into the user configuration directory and deleting
 #' this directory should return the application to a default settings.
 #'
-#' @param appname is the name of application.
+#' @param appname is the name of application. If NULL, just the system
+#'     directory is returned.
 #' @param appauthor (only required and used on Windows) is the name of the
 #'     appauthor or distributing body for this application. Typically
-#'     it is the owning company name.
+#'     it is the owning company name. This falls back to appname.
 #' @param version is an optional version path element to append to the
 #'     path. You might want to use this if you want multiple versions
 #'     of your app to be able to run independently. If used, this
-#'     would typically be "<major>.<minor>".
+#'     would typically be "<major>.<minor>". Only applied when appname
+#'     is not NULL.
 #' @param roaming (logical, default \code{FALSE}) can be set \code{TRUE} to
 #'     use the Windows roaming appdata directory. That means that for users on
 #'     a Windows network setup for roaming profiles, this user data will be

--- a/R/data.r
+++ b/R/data.r
@@ -67,6 +67,7 @@
 user_data_dir <- function(appname = NULL, appauthor = appname, version = NULL, 
                           roaming = FALSE, expand = TRUE, os = get_os()) {
   if (expand) version <- expand_r_libs_specifiers(version)
+  if (is.null(appname)) { version <- NULL }
   switch(os, 
     win = file_path(win_path(ifelse(roaming, "roaming", "local")), appauthor, appname, version),
     mac = file_path("~/Library/Application Support", appname, version),
@@ -80,6 +81,7 @@ user_data_dir <- function(appname = NULL, appauthor = appname, version = NULL,
 user_config_dir <- function(appname = NULL, appauthor = appname, version = NULL, 
                             roaming = TRUE, expand = TRUE, os = get_os()) {
   if (expand) version <- expand_r_libs_specifiers(version)
+  if (is.null(appname)) { version <- NULL }
   switch(os, 
     win = file_path(win_path(ifelse(roaming, "roaming", "local")), appauthor, appname, version),
     mac = file_path("~/Library/Application Support", appname, version),
@@ -122,6 +124,7 @@ user_config_dir <- function(appname = NULL, appauthor = appname, version = NULL,
 site_data_dir <- function(appname = NULL, appauthor = appname, version = NULL, 
                           multipath = FALSE, expand = TRUE, os = get_os()) {
   if (expand) version <- expand_r_libs_specifiers(version)
+  if (is.null(appname)) { version <- NULL }
   switch(os,
     win = file_path(win_path("common"), appauthor, appname, version),
     mac = file_path("/Library/Application Support", appname, version),
@@ -135,6 +138,7 @@ site_data_dir <- function(appname = NULL, appauthor = appname, version = NULL,
 site_config_dir <- function(appname = NULL, appauthor = appname, version = NULL,
                             multipath = FALSE, expand = TRUE, os = get_os()) {
   if (expand) version <- expand_r_libs_specifiers(version)
+  if (is.null(appname)) { version <- NULL }
   switch(os,
     win = file_path(win_path("common"), appauthor, appname, version),
     mac = file_path("/Library/Application Support", appname, version),

--- a/R/log.r
+++ b/R/log.r
@@ -30,6 +30,7 @@
 user_log_dir <- function(appname = NULL, appauthor = appname, version = NULL, 
                          opinion = TRUE, expand = TRUE, os = get_os()) {
   if (expand) version <- expand_r_libs_specifiers(version)
+  if (is.null(appname)) { version <- NULL }
   switch(os, 
     win = file_path(win_path("local"), appauthor, appname, version, 
       if (opinion) "Logs"),

--- a/R/log.r
+++ b/R/log.r
@@ -4,7 +4,7 @@
 #'
 #' \itemize{
 #'   \item Mac OS X: \file{~/Library/Logs/<AppName>}
-#'   \item Unix: \file{~/.cache/<appname>/log}, or under 
+#'   \item Unix: \file{~/.cache/<AppName>/log}, or under
 #'     \\env{$XDG_CACHE_HOME} if defined
 #'   \item Win XP:  \file{C:\\Documents and Settings\\<username>\\Local Settings\\Application Data\\<AppAuthor>\\<AppName>\\Logs}
 #'   \item Vista: 

--- a/man/app_dir.Rd
+++ b/man/app_dir.Rd
@@ -7,16 +7,18 @@ app_dir(appname = NULL, appauthor = appname, version = NULL,
   expand = TRUE, os = get_os())
 }
 \arguments{
-\item{appname}{is the name of application.}
+\item{appname}{is the name of application. If NULL, just the system
+directory is returned.}
 
 \item{appauthor}{(only required and used on Windows) is the name of the
 appauthor or distributing body for this application. Typically
-it is the owning company name.}
+it is the owning company name. This falls back to appname.}
 
 \item{version}{is an optional version path element to append to the
 path. You might want to use this if you want multiple versions
 of your app to be able to run independently. If used, this
-would typically be "<major>.<minor>".}
+would typically be "<major>.<minor>". Only applied when appname
+is not NULL.}
 
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}

--- a/man/site_data_dir.Rd
+++ b/man/site_data_dir.Rd
@@ -51,7 +51,7 @@ Typical user-shared data directories are:
 }
 Unix also specifies a separate location for user-shared configuration data in \env{$XDG_CONFIG_DIRS}.
 \itemize{
-  \item Unix: \file{/etc/xdg/<appname>}, in \env{$XDG_CONFIG_HOME} if defined
+  \item Unix: \file{/etc/xdg/<AppName>}, in \env{$XDG_CONFIG_HOME} if defined
  }
 
 For Unix, this returns the first default.  Set the \code{multipath=TRUE} to guarantee returning all directories.

--- a/man/site_data_dir.Rd
+++ b/man/site_data_dir.Rd
@@ -15,16 +15,18 @@ site_config_dir(appname = NULL, appauthor = appname, version = NULL,
 which indicates that the entire list of data dirs should be returned
 By default, the first directory is returned}
 
-\item{appname}{is the name of application.}
+\item{appname}{is the name of application. If NULL, just the system
+directory is returned.}
 
 \item{appauthor}{(only required and used on Windows) is the name of the
 appauthor or distributing body for this application. Typically
-it is the owning company name.}
+it is the owning company name. This falls back to appname.}
 
 \item{version}{is an optional version path element to append to the
 path. You might want to use this if you want multiple versions
 of your app to be able to run independently. If used, this
-would typically be "<major>.<minor>".}
+would typically be "<major>.<minor>". Only applied when appname
+is not NULL.}
 
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}

--- a/man/user_cache_dir.Rd
+++ b/man/user_cache_dir.Rd
@@ -34,7 +34,7 @@ Typical user cache directories are:
 \details{
 \itemize{
  \item Mac OS X: \file{~/Library/Caches/<AppName>}
- \item Unix: \file{~/.cache/<appname>}, \env{$XDG_CACHE_HOME} if defined
+ \item Unix: \file{~/.cache/<AppName>}, \env{$XDG_CACHE_HOME} if defined
  \item Win XP: \file{C:\\Documents and Settings\\<username>\\Local Settings\\Application Data\\<AppAuthor>\\<AppName>\\Cache}
  \item Vista:      \file{C:\\Users\\<username>\\AppData\\Local\\<AppAuthor>\\<AppName>\\Cache}
 }

--- a/man/user_cache_dir.Rd
+++ b/man/user_cache_dir.Rd
@@ -10,16 +10,18 @@ user_cache_dir(appname = NULL, appauthor = appname, version = NULL,
 \item{opinion}{(logical) can be \code{FALSE} to disable the appending of
 \file{Cache} to the base app data dir for Windows. See discussion below.}
 
-\item{appname}{is the name of application.}
+\item{appname}{is the name of application. If NULL, just the system
+directory is returned.}
 
 \item{appauthor}{(only required and used on Windows) is the name of the
 appauthor or distributing body for this application. Typically
-it is the owning company name.}
+it is the owning company name. This falls back to appname.}
 
 \item{version}{is an optional version path element to append to the
 path. You might want to use this if you want multiple versions
 of your app to be able to run independently. If used, this
-would typically be "<major>.<minor>".}
+would typically be "<major>.<minor>". Only applied when appname
+is not NULL.}
 
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}

--- a/man/user_data_dir.Rd
+++ b/man/user_data_dir.Rd
@@ -46,7 +46,7 @@ Typical user data directories are:
 
 \itemize{
   \item Mac OS X:  \file{~/Library/Application Support/<AppName>}
-  \item Unix: \file{~/.local/share/<appname>}, in \env{$XDG_DATA_HOME} if defined
+  \item Unix: \file{~/.local/share/<AppName>}, in \env{$XDG_DATA_HOME} if defined
   \item Win XP (not roaming):  \file{C:\\Documents and Settings\\<username>\\Data\\<AppAuthor>\\<AppName>}
   \item Win XP (roaming): \file{C:\\Documents and Settings\\<username>\\Local Settings\\Data\\<AppAuthor>\\<AppName>}
   \item Win 7  (not roaming):
@@ -56,7 +56,7 @@ Typical user data directories are:
 }
 Unix also specifies a separate location for user configuration data in
 \itemize{
-  \item Unix: \file{~/.config/<appname>}, in \env{$XDG_CONFIG_HOME} if defined
+  \item Unix: \file{~/.config/<AppName>}, in \env{$XDG_CONFIG_HOME} if defined
  }
 See for example \url{http://ploum.net/184-cleaning-user-preferences-keeping-user-data/}
 or \url{http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html} for more information.

--- a/man/user_data_dir.Rd
+++ b/man/user_data_dir.Rd
@@ -11,16 +11,18 @@ user_config_dir(appname = NULL, appauthor = appname, version = NULL,
   roaming = TRUE, expand = TRUE, os = get_os())
 }
 \arguments{
-\item{appname}{is the name of application.}
+\item{appname}{is the name of application. If NULL, just the system
+directory is returned.}
 
 \item{appauthor}{(only required and used on Windows) is the name of the
 appauthor or distributing body for this application. Typically
-it is the owning company name.}
+it is the owning company name. This falls back to appname.}
 
 \item{version}{is an optional version path element to append to the
 path. You might want to use this if you want multiple versions
 of your app to be able to run independently. If used, this
-would typically be "<major>.<minor>".}
+would typically be "<major>.<minor>". Only applied when appname
+is not NULL.}
 
 \item{roaming}{(logical, default \code{FALSE}) can be set \code{TRUE} to
 use the Windows roaming appdata directory. That means that for users on

--- a/man/user_log_dir.Rd
+++ b/man/user_log_dir.Rd
@@ -35,7 +35,7 @@ Typical user cache directories are:
 \details{
 \itemize{
   \item Mac OS X: \file{~/Library/Logs/<AppName>}
-  \item Unix: \file{~/.cache/<appname>/log}, or under
+  \item Unix: \file{~/.cache/<AppName>/log}, or under
     \\env{$XDG_CACHE_HOME} if defined
   \item Win XP:  \file{C:\\Documents and Settings\\<username>\\Local Settings\\Application Data\\<AppAuthor>\\<AppName>\\Logs}
   \item Vista:

--- a/man/user_log_dir.Rd
+++ b/man/user_log_dir.Rd
@@ -11,16 +11,18 @@ user_log_dir(appname = NULL, appauthor = appname, version = NULL,
 \file{Logs} to the base app data dir for Windows, and \file{log} to the
 base cache dir for Unix. See discussion below.}
 
-\item{appname}{is the name of application.}
+\item{appname}{is the name of application. If NULL, just the system
+directory is returned.}
 
 \item{appauthor}{(only required and used on Windows) is the name of the
 appauthor or distributing body for this application. Typically
-it is the owning company name.}
+it is the owning company name. This falls back to appname.}
 
 \item{version}{is an optional version path element to append to the
 path. You might want to use this if you want multiple versions
 of your app to be able to run independently. If used, this
-would typically be "<major>.<minor>".}
+would typically be "<major>.<minor>". Only applied when appname
+is not NULL.}
 
 \item{expand}{If TRUE (the default) will expand the \code{R_LIBS} specifiers with their equivalents.
      See \code{\link{R_LIBS}} for list of all possibly specifiers.}


### PR DESCRIPTION
This is a minor reworking of commits originally due to Gabor Csardi to be compatible with my current master. They correspond to
- Docs: `<appname>` -> `<AppName>` to avoid confusion …   9a8687b
- Docs: comment on appauthor -> appname fallback …    a775800
- Only use version if appname is not NULL …   7512326

The reason the commits could not be applied straight is largely because of roxygen2 4.0.1 wrap settings.
